### PR TITLE
Add parameter recipient_delimiter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class mail (
   $server_label              = $::mail::params::server_label,
   $virtual_domains           = $::mail::params::virtual_domains,
   $virtual_addresses         = $::mail::params::virtual_addresses,
+  $recipient_delimiter       = $::mail::params::recipient_delimiter,
   $enable_antispam           = $::mail::params::enable_antispam,
   $antispam_sa_score         = $::mail::params::antispam_sa_score,
   $enable_graylisting        = $::mail::params::enable_graylisting,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,6 +58,14 @@ class mail::params {
   #
   $virtual_addresses = {}
 
+  # The recipient_delimiter parameter specifies the separator between
+  # user names and address extensions (user+foo). See canonical(5),
+  # local(8), relocated(5) and virtual(5) for the effects this has on
+  # aliases, canonical, virtual, relocated and .forward file lookups.
+  # Basically, the software tries user+foo and .forward+foo before
+  # trying user and .forward.
+  $recipient_delimiter = undef
+
 
   # Enable spam filtering using SpamAssassin. If disabled, none of the other
   # subsequent antispam_* settings have any effect.

--- a/manifests/postfix.pp
+++ b/manifests/postfix.pp
@@ -18,6 +18,7 @@ class mail::postfix (
   $antispam_sa_score         = $::mail::antispam_sa_score,
   $max_message_size_mb       = $::mail::max_message_size_mb,
   $path_dovecot_lda          = $::mail::path_dovecot_lda,
+  $recipient_delimiter       = $::mail::recipient_delimiter,
   ) {
 
   # Install additional dependencies
@@ -49,6 +50,9 @@ class mail::postfix (
     # Virtual domains & mappings
     virtual_alias_maps      => ['hash:/etc/postfix/virtual'],
     virtual_mailbox_domains => $virtual_domains_tweaked,
+
+    # Recipient delimitier
+    recipient_delimiter => $recipient_delimiter,
 
     # Dovecot Integration
     # Note: need both mailbox_command and virtual_transport to cater for both virtual and real users alike.


### PR DESCRIPTION
The recipient delimiter parameter is nice to have in order to manage tag
mails addresses.
Default behavior is not to use it.